### PR TITLE
Add plot target to makefile, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@
 *.o
 a.out
 *.a
-bench/xdl1blastst
-test/dblat1_*
+*.dat
+*.png
+*.bak
+bench/xdl[1-3]blastst
+test/dblat[1-3]_*
+bench/report
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ a.out
 *.a
 *.dat
 *.png
+*.svg
 *.bak
 bench/xdl[1-3]blastst
 test/dblat[1-3]_*
 bench/report
+bench/branches
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ $(DIRS):
 bench: src refblas
 test: src refblas
 
+.PHONY: plot
+plot: bench
+	make -C bench plot
+
 .PHONY: clean
 clean:
 	-for dir in $(DIRS); do make -C $$dir clean; done

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -49,11 +49,15 @@ libtstatlas.a : $(ATL_OBJECTFILES)
 .PHONY: plot
 plot: xdl3blastst
 	./xdl3blastst -N 100 2000 100 > report
-	grep PASS report > $(BRANCH).dat
 	grep "\ \-\-\-\-\-$$"  report > refBLAS.dat
-	gnuplot -e "build=\"$(BRANCH)\"" bench.gps
-	open $(BRANCH).png
+	grep PASS report > $(BRANCH).dat
+	# List the branch for comparision
+	grep -Fxq "refBLAS"   branches || echo refBLAS   >> branches
+	grep -Fxq "$(BRANCH)" branches || echo $(BRANCH) >> branches
+	gnuplot -e "BRANCHES=\"$(shell cat branches)\"" bench.gps
+	open bench.png
 
 clean:
-	rm -f xdl1blastst libtstatlas.a l1blastst.o $(ATL_OBJECTFILES)
-	rm -f report refBLAS.dat $(BRANCH).dat $(BRANCH).png
+	rm -f xdl[1-3]blastst libtstatlas.a l[1-3]blastst.o $(ATL_OBJECTFILES)
+	rm -f report branches *.dat bench.png
+

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -12,6 +12,8 @@ CFLAGS = -c -DL2SIZE=4194304 -DAdd_ -DF77_INTEGER=int -DStringSunStyle \
 
 LDFLAGS = -lm
 
+BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
 #
 #  Select the ATLAS library (or our faked ATLAS implementation)
 #
@@ -43,6 +45,14 @@ xdl3blastst : l3blastst.o libtstatlas.a $(ATLAS_LIB) $(REF_LIB)
 libtstatlas.a : $(ATL_OBJECTFILES)
 	ar r libtstatlas.a $(ATL_OBJECTFILES)
 	ranlib libtstatlas.a
+
+.PHONY: plot
+plot: xdl3blastst
+	./xdl3blastst -N 100 2000 100 > report
+	grep PASS report > $(BRANCH)
+	grep "\ \-\-\-\-\-$$"  report > refBLAS
+	gnuplot -e "build=\"$(BRANCH)\"" bench.gps
+	open $(BRANCH).png
 
 clean:
 	rm -f xdl1blastst libtstatlas.a l1blastst.o $(ATL_OBJECTFILES)

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -49,15 +49,15 @@ libtstatlas.a : $(ATL_OBJECTFILES)
 .PHONY: plot
 plot: xdl3blastst
 	./xdl3blastst -N 100 2000 100 > report
-	grep "\ \-\-\-\-\-$$"  report > refBLAS.dat
+	grep "\ \-\-\-\-\-$$"  report > Netlib-refBLAS.dat
 	grep PASS report > $(BRANCH).dat
 	# List the branch for comparision
-	grep -Fxq "refBLAS"   branches || echo refBLAS   >> branches
-	grep -Fxq "$(BRANCH)" branches || echo $(BRANCH) >> branches
+	grep -Fxq "Netlib-refBLAS" branches || echo Netlib-refBLAS >> branches
+	grep -Fxq "$(BRANCH)"      branches || echo $(BRANCH)      >> branches
 	gnuplot -e "BRANCHES=\"$(shell cat branches)\"" bench.gps
-	open bench.png
+	xdg-open comp.svg || open comp.svg || echo "Benchmark plotted as bench/comp.svg"
 
 clean:
 	rm -f xdl[1-3]blastst libtstatlas.a l[1-3]blastst.o $(ATL_OBJECTFILES)
-	rm -f report branches *.dat bench.png
+	rm -f report branches *.dat comp.svg
 

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -49,10 +49,11 @@ libtstatlas.a : $(ATL_OBJECTFILES)
 .PHONY: plot
 plot: xdl3blastst
 	./xdl3blastst -N 100 2000 100 > report
-	grep PASS report > $(BRANCH)
-	grep "\ \-\-\-\-\-$$"  report > refBLAS
+	grep PASS report > $(BRANCH).dat
+	grep "\ \-\-\-\-\-$$"  report > refBLAS.dat
 	gnuplot -e "build=\"$(BRANCH)\"" bench.gps
 	open $(BRANCH).png
 
 clean:
 	rm -f xdl1blastst libtstatlas.a l1blastst.o $(ATL_OBJECTFILES)
+	rm -f report refBLAS.dat $(BRANCH).dat $(BRANCH).png

--- a/bench/bench.gps
+++ b/bench/bench.gps
@@ -1,7 +1,10 @@
+#! /usr/bin/gnuplot
+if (!exists("build")) build='ulmBLAS'
+
 set terminal png size 940,480
-set output "bench.png"
+set output build.".png"
 set xlabel "Matrix dimensions N=M=K"
 set ylabel "MFLOPS"
 set yrange [0:9600]
 set key outside
-plot "refBLAS" using 4:13 with linespoints lt 2 title "Netlib RefBLAS", "demo-naive-avx-with-intrinsics" using 4:13 with linespoints lt 4 title "demo-naive-avx-with-intrinsics"
+plot "refBLAS" using 4:13 with linespoints lt 2 title "Netlib RefBLAS", build using 4:13 with linespoints lt 4 title build

--- a/bench/bench.gps
+++ b/bench/bench.gps
@@ -7,4 +7,4 @@ set xlabel "Matrix dimensions N=M=K"
 set ylabel "MFLOPS"
 set yrange [0:9600]
 set key outside
-plot "refBLAS" using 4:13 with linespoints lt 2 title "Netlib RefBLAS", build using 4:13 with linespoints lt 4 title build
+plot "refBLAS.dat" using 4:13 with linespoints lt 2 title "Netlib RefBLAS", build.".dat" using 4:13 with linespoints lt 4 title build

--- a/bench/bench.gps
+++ b/bench/bench.gps
@@ -1,8 +1,8 @@
 #! /usr/bin/gnuplot
 if (!exists("BRANCHES")) BRANCHES='ulmBLAS'
 
-set terminal png size 1140,480
-set output "bench.png"
+set terminal svg size 1140,480
+set output "comp.svg"
 set title "dgemm: Compute C + A*B"
 set xlabel "Matrix dimensions N=M=K"
 set ylabel "MFLOPS"

--- a/bench/bench.gps
+++ b/bench/bench.gps
@@ -1,10 +1,12 @@
 #! /usr/bin/gnuplot
-if (!exists("build")) build='ulmBLAS'
+if (!exists("BRANCHES")) BRANCHES='ulmBLAS'
 
-set terminal png size 940,480
-set output build.".png"
+set terminal png size 1140,480
+set output "bench.png"
+set title "dgemm: Compute C + A*B"
 set xlabel "Matrix dimensions N=M=K"
 set ylabel "MFLOPS"
 set yrange [0:9600]
 set key outside
-plot "refBLAS.dat" using 4:13 with linespoints lt 2 title "Netlib RefBLAS", build.".dat" using 4:13 with linespoints lt 4 title build
+plot for [file in BRANCHES] file.'.dat' using 4:13 w lp title file
+


### PR DESCRIPTION
A plot comparing the performance of the curent branch against refBLAST can now be generated by
make plot

Unfortunately, the y-axis scale is currently fixed - the clean implementation would be to get the peak performance from
/proc/cpuinfo

Some level3 related files and the products of 'make plot' are added to the .gitignore file.

Given the broad use of these changes, I hope for them to be cherry-picked to all level3 implemention branches.

Co-author: Dirk Nille
